### PR TITLE
Feature to send "vars" update to webhook

### DIFF
--- a/src/tools/send_webhooks.js
+++ b/src/tools/send_webhooks.js
@@ -1,6 +1,7 @@
 const { WebhookClient } = require('discord.js');
 const sendCommitEmbed = require('./utils/new_commit');
 const sendImagesToWebhook = require('./utils/send_images');
+const sendVars = require('./utils/send_vars');
 const argv = require('minimist')(process.argv.slice(2))
 
 const webhookUrl = process.env.WEBHOOK_URL;
@@ -30,6 +31,7 @@ async function runTasks() {
     }
 
     await sendCommitEmbed(commitSha, webhookClient);
+    await sendVars(commitSha, webhookClient);
     await sendImagesToWebhook(commitSha, webhookClient);
 }
 

--- a/src/tools/utils/send_vars.js
+++ b/src/tools/utils/send_vars.js
@@ -1,0 +1,22 @@
+const { generateDiscordDiffMessages, formatName } = require('./utils')
+
+async function sendVars(commitSha, webhookClient) {
+    const fileToMessagesMap = generateDiscordDiffMessages(commitSha)
+
+    for (const [file, messages] of fileToMessagesMap.entries()) {
+        let messageContent
+
+        for (const message of messages) {
+            if (!messageContent) {
+                messageContent = `${formatName(file)}\n${message}`
+            }
+            else {
+                messageContent = message
+            }
+
+            await webhookClient.send({ content: messageContent })
+        }
+    }
+}
+
+module.exports = sendVars

--- a/src/tools/utils/utils.js
+++ b/src/tools/utils/utils.js
@@ -39,14 +39,60 @@ function getCommitDetails(commitSha) {
       badges: 'Badge',
       clothes: 'Clothe',
       effects: 'Effect',
-      furnis: 'Furni'
+      furnis: 'Furni',
+      gamedata: 'Vars'
     }
   
     const parts = filePath.includes('/') ? filePath.split('/') : filePath.split('\\')
     const domain = domains.filter((d) => parts.includes(d)).pop()
     const type = types[Object.keys(types).filter((type) => parts.includes(type)).pop()]
-    const name = path.basename(filePath).substring(0, path.basename(filePath).lastIndexOf('.'))
+    const name = type === 'Vars' ? path.basename(filePath) : path.basename(filePath).substring(0, path.basename(filePath).lastIndexOf('.'))
     return domain ? `> ${type} (${domain}): ${name}` : `> ${type}: ${name}` 
   }
 
-  module.exports = { getCommitDetails, getBranchName, getUserAvatar, getLastCommitFiles, isImage, formatName }
+  function getCommitLines(commitSha) {
+    return execSync(`git show ${commitSha}`)
+    .toString()
+    .trim()
+    .split('\n')
+  }
+
+function generateDiscordDiffMessages(commitSha) {
+      const fileToMessagesMap = new Map()
+      const characterLimit = 1800 // max character amount in a single message
+      let currentFile
+      let message
+      const commitLines = getCommitLines(commitSha)
+      for (const line of commitLines) {
+          const match = line.match(/diff --git a\/([^ ]+)/)
+          if (match) {
+              if (message?.length > 7) {
+                  message += '\n```'
+                  fileToMessagesMap.get(currentFile).push(message)
+              }
+              
+              fileToMessagesMap.set(match[1], [])
+              currentFile = match[1]
+              message = '```diff'
+          }
+
+          if ((line.startsWith('+') || line.startsWith('-')) && !(line.startsWith('+++') || line.startsWith('---'))) {
+              message += `\n${line}`
+
+              if (message.length >= characterLimit) {
+                  message += '\n```'
+                  fileToMessagesMap.get(currentFile).push(message)
+                  message = '```diff'
+              }
+          }
+      }
+
+      if (message?.length > 7) {
+        message += '\n```'
+        fileToMessagesMap.get(currentFile).push(message)
+      }
+
+      return fileToMessagesMap
+}
+
+  module.exports = { getCommitDetails, getBranchName, getUserAvatar, getLastCommitFiles, isImage, formatName, generateDiscordDiffMessages }


### PR DESCRIPTION
in order to be able to compare gamedata files' diffs "line by line", i needed to prettify some one-lined (ugly) gamedata files and make them multi-line, so diffs will not be too large
for example since furnidata.json is originally one-lined, even when a few fields are updated, the diff is too large that can't be viewed on github website as seen below, and also we can't see the difference in a more readable way, that's why furnidata.json (and other some gamedatafiles) need to be pretified
![image](https://github.com/Hab-Track/Habbo-Track/assets/163551540/748e99ec-cebb-4cac-8dbb-7062ba1d4293)
